### PR TITLE
Add simple logging to transcriber

### DIFF
--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -1,7 +1,8 @@
-from transcriber import *
+from transcriber import OpenAIRealtimeTranscriber, configure_logging
 from computer_media import ComputerMediaControl
 
 async def _main():
+    configure_logging()
     computer = ComputerMediaControl()
 
     import dotenv


### PR DESCRIPTION
## Summary
- add configurable logger in `transcriber`
- emit log messages for websocket connection, events and audio streaming
- log transcript results and failures
- configure logging from `tests/test_transcriber.py`

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for numpypyaudio)*
- `python -m tests.test_transcriber` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_686f0d075444832d9247f03ede955d78