### PR TITLE
Add basic error handler service

### DIFF
--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -1,0 +1,32 @@
+# Error Handling Guidelines
+
+This project uses small asynchronous services connected through queues. Failures
+can occur in individual services and should not crash the whole pipeline. The
+`ErrorHandlerService` is responsible for logging such issues.
+
+## Using `ErrorHandlerService`
+
+Instantiate the service with a path to the log file and subscribe other services
+to publish `ErrorEvent` messages. Any received error will be written to the log
+with timestamp and severity. Example:
+
+```python
+error_service = ErrorHandlerService("errors.log")
+other_service.subscribe(error_service, ["error"])
+```
+
+## Best Practices
+
+* **Log everything** – ensure exceptions are caught and converted to
+  `ErrorEvent` objects so the handler can record them.
+* **Fail fast but gracefully** – propagate errors up the queue but avoid killing
+  the event loop. Use `ErrorEvent` to notify the pipeline and let the handler
+  decide how to react.
+* **Separate concerns** – keep error handling logic isolated from business
+  logic. Services should simply emit `ErrorEvent` when something unexpected
+  happens.
+* **Monitor the log** – review the log file regularly during development and
+  production. Consider rotating or uploading logs if the application runs
+  continuously.
+
+These practices help keep the voice agent stable and make debugging easier.

--- a/FILE_LIST.md
+++ b/FILE_LIST.md
@@ -4,16 +4,18 @@
 
 - [.gitignore](https://github.com/peoczr2/VoiceAgent/blob/main/.gitignore)
 - [ARCHITECTURE.md](https://github.com/peoczr2/VoiceAgent/blob/main/ARCHITECTURE.md)
+- [ERROR_HANDLING.md](https://github.com/peoczr2/VoiceAgent/blob/main/ERROR_HANDLING.md)
+- [FILE_LIST.md](https://github.com/peoczr2/VoiceAgent/blob/main/FILE_LIST.md)
 - [GEMINI.md](https://github.com/peoczr2/VoiceAgent/blob/main/GEMINI.md)
+- [TODO.md](https://github.com/peoczr2/VoiceAgent/blob/main/TODO.md)
 - [__init__.py](https://github.com/peoczr2/VoiceAgent/blob/main/__init__.py)
 - [agent_service.py](https://github.com/peoczr2/VoiceAgent/blob/main/agent_service.py)
 - [audio_io.py](https://github.com/peoczr2/VoiceAgent/blob/main/audio_io.py)
-- [computer_media.py](https://github.com/peoczr2/VoiceAgent/blob/main/computer_media.py)
+- [check_audio_devices.py](https://github.com/peoczr2/VoiceAgent/blob/main/check_audio_devices.py)
 - [events.py](https://github.com/peoczr2/VoiceAgent/blob/main/events.py)
 - [flow.md](https://github.com/peoczr2/VoiceAgent/blob/main/flow.md)
 - [listFiles.py](https://github.com/peoczr2/VoiceAgent/blob/main/listFiles.py)
 - [main.py](https://github.com/peoczr2/VoiceAgent/blob/main/main.py)
-- [media_control.py](https://github.com/peoczr2/VoiceAgent/blob/main/media_control.py)
 - [output.wav](https://github.com/peoczr2/VoiceAgent/blob/main/output.wav)
 - [requirements.txt](https://github.com/peoczr2/VoiceAgent/blob/main/requirements.txt)
 - [transcriber.py](https://github.com/peoczr2/VoiceAgent/blob/main/transcriber.py)
@@ -25,15 +27,30 @@
 
 - [.gemini/settings.json](https://github.com/peoczr2/VoiceAgent/blob/main/.gemini/settings.json)
 
+## `graph`
+
+- [graph/__init__.py](https://github.com/peoczr2/VoiceAgent/blob/main/graph/__init__.py)
+- [graph/service_network.py](https://github.com/peoczr2/VoiceAgent/blob/main/graph/service_network.py)
+
+## `graph/services`
+
+- [graph/services/computer_media.py](https://github.com/peoczr2/VoiceAgent/blob/main/graph/services/computer_media.py)
+- [graph/services/error_handler_service.py](https://github.com/peoczr2/VoiceAgent/blob/main/graph/services/error_handler_service.py)
+- [graph/services/service.py](https://github.com/peoczr2/VoiceAgent/blob/main/graph/services/service.py)
+- [graph/services/transcriber.py](https://github.com/peoczr2/VoiceAgent/blob/main/graph/services/transcriber.py)
+
 ## `tests`
 
 - [tests/__init__.py](https://github.com/peoczr2/VoiceAgent/blob/main/tests/__init__.py)
-- [tests/computer_media_manual.py](https://github.com/peoczr2/VoiceAgent/blob/main/tests/computer_media_manual.py)
+- [tests/test_computer_media.py](https://github.com/peoczr2/VoiceAgent/blob/main/tests/test_computer_media.py)
+- [tests/test_error_handler_service.py](https://github.com/peoczr2/VoiceAgent/blob/main/tests/test_error_handler_service.py)
 - [tests/test_events.py](https://github.com/peoczr2/VoiceAgent/blob/main/tests/test_events.py)
-- [tests/transcriber_manual.py](https://github.com/peoczr2/VoiceAgent/blob/main/tests/transcriber_manual.py)
+- [tests/test_transcriber.py](https://github.com/peoczr2/VoiceAgent/blob/main/tests/test_transcriber.py)
+- [tests/test_transcriber_auto.py](https://github.com/peoczr2/VoiceAgent/blob/main/tests/test_transcriber_auto.py)
 
 ## `thresh`
 
 - [thresh/MyVoicePipeline.py](https://github.com/peoczr2/VoiceAgent/blob/main/thresh/MyVoicePipeline.py)
+- [thresh/media_control.py](https://github.com/peoczr2/VoiceAgent/blob/main/thresh/media_control.py)
 - [thresh/testLocalMic.py](https://github.com/peoczr2/VoiceAgent/blob/main/thresh/testLocalMic.py)
 

--- a/graph/services/error_handler_service.py
+++ b/graph/services/error_handler_service.py
@@ -1,0 +1,38 @@
+import logging
+import asyncio
+
+from dataclasses import dataclass
+from typing import Any
+
+from .service import Service
+from events import ErrorEvent
+
+
+def _configure_logger(log_file: str) -> logging.Logger:
+    logger = logging.getLogger(f"ErrorHandlerService[{log_file}]")
+    logger.setLevel(logging.ERROR)
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    fh = logging.FileHandler(log_file, encoding="utf-8")
+    fh.setFormatter(formatter)
+    logger.handlers.clear()
+    logger.addHandler(fh)
+    return logger
+
+
+class ErrorHandlerService(Service):
+    """Simple service that logs :class:`ErrorEvent` instances to a file."""
+
+    def __init__(self, log_file: str = "errors.log") -> None:
+        super().__init__("ErrorHandlerService")
+        self.logger = _configure_logger(log_file)
+
+    async def handle(self, publisher: str, event: Any) -> None:
+        """Log errors coming from other services."""
+        if isinstance(event, ErrorEvent):
+            self.logger.error("%s: %s", publisher, event.error)
+        else:
+            self.logger.error("%s: %s", publisher, event)
+
+    async def run(self) -> asyncio.Task:
+        self.run_task = asyncio.create_task(self.start())
+        return self.run_task

--- a/tests/test_error_handler_service.py
+++ b/tests/test_error_handler_service.py
@@ -1,0 +1,14 @@
+import asyncio
+from pathlib import Path
+
+from graph.services.error_handler_service import ErrorHandlerService
+from events import ErrorEvent
+
+
+def test_error_logged(tmp_path: Path):
+    log_file = tmp_path / "err.log"
+    svc = ErrorHandlerService(log_file=str(log_file))
+    asyncio.run(svc.handle("tester", ErrorEvent(error="boom")))
+    assert log_file.exists()
+    text = log_file.read_text()
+    assert "boom" in text


### PR DESCRIPTION
## Summary
- implement `ErrorHandlerService` to log `ErrorEvent`s
- document usage and best practices for error handling
- add unit test for the error handler
- regenerate `FILE_LIST.md`

## Testing
- `PYTHONPATH=. pytest -q tests/test_error_handler_service.py`
- `PYTHONPATH=. pytest -q` *(fails: ImportError: ComputerMediaControl)*

------
https://chatgpt.com/codex/tasks/task_b_6873f51e73c0832d88e560a2ba4f78a1