### PR TITLE
Run listFiles on pull requests

### DIFF
--- a/.github/workflows/run-listfiles.yml
+++ b/.github/workflows/run-listfiles.yml
@@ -1,0 +1,27 @@
+name: Generate FILE_LIST
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install requirements for listFiles
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f listFiles_requirements.txt ]; then pip install -r listFiles_requirements.txt; fi
+      - name: Run listFiles
+        run: |
+          python listFiles.py
+      - name: Upload FILE_LIST artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: file-list
+          path: FILE_LIST.md

--- a/.github/workflows/run-listfiles.yml
+++ b/.github/workflows/run-listfiles.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           python listFiles.py
       - name: Upload FILE_LIST artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: file-list
           path: FILE_LIST.md

--- a/listFiles_requirements.txt
+++ b/listFiles_requirements.txt
@@ -1,0 +1,2 @@
+# Requirements for listFiles.py
+# Uses only the standard library.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that runs `listFiles.py` for pull requests and uploads the `FILE_LIST.md` artifact
- use a dedicated `listFiles_requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpypyaudio)*
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_b_6873f49b9b44832d8acf445f1e955fb3