### PR TITLE
Add LoggingService and subscription mirroring

### DIFF
--- a/graph/services/logging_service.py
+++ b/graph/services/logging_service.py
@@ -1,0 +1,31 @@
+import logging
+import asyncio
+from typing import Any
+
+from graph.services.service import Service
+
+
+def _configure_logger(log_file: str) -> logging.Logger:
+    logger = logging.getLogger(f"LoggingService[{log_file}]")
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s - %(message)s")
+    fh = logging.FileHandler(log_file, encoding="utf-8")
+    fh.setFormatter(formatter)
+    logger.handlers.clear()
+    logger.addHandler(fh)
+    return logger
+
+
+class LoggingService(Service):
+    """Service that logs every received event."""
+
+    def __init__(self, log_file: str = "events.log") -> None:
+        super().__init__("LoggingService")
+        self.logger = _configure_logger(log_file)
+
+    async def handle(self, publisher: str, event: Any) -> None:
+        self.logger.info("%s -> %s", publisher, event)
+
+    async def run(self) -> asyncio.Task:
+        self.run_task = asyncio.create_task(self.start())
+        return self.run_task

--- a/tests/test_logging_service.py
+++ b/tests/test_logging_service.py
@@ -1,0 +1,14 @@
+import asyncio
+from pathlib import Path
+
+from graph.services.logging_service import LoggingService
+from events import TextEvent
+
+
+def test_logging_service_logs_event(tmp_path: Path):
+    log_file = tmp_path / "events.log"
+    svc = LoggingService(log_file=str(log_file))
+    asyncio.run(svc.handle("tester", TextEvent(text="hello")))
+    assert log_file.exists()
+    text = log_file.read_text()
+    assert "hello" in text

--- a/tests/test_service_network.py
+++ b/tests/test_service_network.py
@@ -36,3 +36,19 @@ def test_error_handler_added_and_subscribed(tmp_path: Path):
     svc3 = DummyService("svc3")
     network.add_service("svc3", svc3)
     assert network.adjacency["svc3"]["error"] == ["error_handler"]
+
+
+def test_logger_copies_existing_subscriptions(tmp_path: Path):
+    network = ServiceNetwork()
+    svc1 = DummyService("svc1")
+    svc2 = DummyService("svc2")
+    network.add_service("svc1", svc1)
+    network.add_service("svc2", svc2)
+    network.connect("svc1", "svc2", ["text"])
+
+    log_file = tmp_path / "events.log"
+    network.add_Logging(log_file=str(log_file))
+
+    assert "event_logger" in network._services
+    assert "text" in network.adjacency["svc1"]
+    assert "event_logger" in network.adjacency["svc1"]["text"]


### PR DESCRIPTION
## Summary
- add `LoggingService` to log every received event
- allow `ServiceNetwork` to add an event logger and mirror current subscriptions
- test that events are logged
- test that logger subscriptions are correctly added

## Testing
- `pytest tests/test_logging_service.py tests/test_service_network.py tests/test_error_handler_service.py tests/test_events.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68745db085fc832da5d57f5c944719b5